### PR TITLE
Fix lost `[:parameters :multipart]` in `defaults-middleware`

### DIFF
--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -1,8 +1,8 @@
 (ns reitit.ring.middleware.defaults
   (:refer-clojure :exclude [compile])
-  (:require [reitit.ring.coercion :as coercion]
+  (:require [reitit.coercion :as rc]
+            [reitit.ring.coercion :as coercion]
             [reitit.ring.middleware.exception :as exception]
-            [reitit.ring.middleware.multipart :as multipart]
             [reitit.ring.middleware.muuntaja :as format]
             [reitit.ring.middleware.parameters :as parameters]
             [ring.middleware.absolute-redirects :refer [wrap-absolute-redirects]]
@@ -12,6 +12,7 @@
             [ring.middleware.default-charset :refer [wrap-default-charset]]
             [ring.middleware.flash :refer [wrap-flash]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [ring.middleware.multipart-params :refer [wrap-multipart-params]]
             [ring.middleware.nested-params :refer [wrap-nested-params]]
             [ring.middleware.not-modified :refer [wrap-not-modified]]
             [ring.middleware.proxy-headers :refer [wrap-forwarded-remote-addr]]
@@ -94,13 +95,22 @@
               (when (get-in data [:defaults :params :urlencoded])
                 parameters/parameters-middleware))})
 
-(def multipart-middleware
-  {:name ::multipart
+(def multipart-parsing-middleware
+  "Parses multipart params into `:multipart-params` and `:params`, like
+   the stock `ring.middleware.multipart-params/wrap-multipart-params`.
+
+   Parsing only: coercion into `[:parameters :multipart]` is done by the
+   `multipart-coercion-middleware`, mounted after request coercion.
+
+   Splitting into separate parsing and coercion steps also lets coercion
+   errors surface inside `coercion/coerce-exceptions-middleware` as 400s
+   instead of escaping the chain as 500s."
+  {:name ::multipart-parsing
    :compile (fn [data _]
               (when-let [opts (get-in data [:defaults :params :multipart])]
                 (if (true? opts)
-                  multipart/multipart-middleware
-                  (multipart/create-multipart-middleware opts))))})
+                  wrap-multipart-params
+                  #(wrap-multipart-params % opts))))})
 
 (def nested-params-middleware
   {:name ::nested-params
@@ -130,6 +140,41 @@
                   (exception/create-exception-middleware handlers)
                   exception/exception-middleware)))})
 
+(defn- coerced-request [request coercers]
+  (if-let [coerced (if coercers (rc/coerce-request coercers request))]
+    (update request :parameters merge coerced)
+    request))
+
+(def multipart-coercion-middleware
+  "Coerces the multipart params pre-parsed by `multipart-parsing-middleware`
+   into `[:parameters :multipart]`.
+
+   Coercion only: the request body is not touched. Must be mounted after the
+   `coercion/coerce-request-middleware`, which overwrites `:parameters` and
+   would discard anything merged into it earlier.
+
+   It mounts only when multipart params are enabled in the `:defaults` route
+   data and the route has a `:multipart` params schema."
+  {:name ::multipart-coercion
+   :compile (fn [{:keys [parameters coercion] :as data} route-opts]
+              (when (and (get-in data [:defaults :params :multipart])
+                         (:multipart parameters))
+                (let [parameter-coercion {:multipart (rc/->ParameterCoercion
+                                                      :multipart-params :string true true)}
+                      opts (assoc route-opts ::rc/parameter-coercion parameter-coercion)
+                      coercers (rc/request-coercers coercion parameters opts)]
+                  {:data {:swagger {:consumes ^:replace #{"multipart/form-data"}}}
+                   :wrap (fn [handler]
+                           (fn
+                             ([request]
+                              (-> request
+                                  (coerced-request coercers)
+                                  (handler)))
+                             ([request respond raise]
+                              (-> request
+                                  (coerced-request coercers)
+                                  (handler respond raise)))))})))})
+
 (def ring-defaults-middleware
   "Applies the same middleware as `ring.middleware.defaults/wrap-defaults`,
    but as Reitit data-driven middleware with per-route compilation.
@@ -157,7 +202,7 @@
    cookies-middleware
 
    params-middleware
-   multipart-middleware
+   multipart-parsing-middleware
    nested-params-middleware
    keyword-params-middleware
 
@@ -168,11 +213,20 @@
 
 (def defaults-middleware
   "All of `ring-defaults-middleware`, plus Reitit's content negotiation
-   (using Muuntaja), exception and coercion middleware."
+   (using Muuntaja), exception and coercion middleware.
+
+   IMPLEMENTATION NOTE:
+   Reitit's multipart middleware parses and coerces in a single wrap, but
+   the two halves have contradictory placement requirements: parsing must
+   happen before the `nested-params`, `keyword-params` and `anti-forgery`
+   middleware, which expect multipart params merged into `:params`, while
+   the coercion result only survives after `coerce-request-middleware`,
+   which overwrites `:parameters` wholesale (see the note added in 0.10.0
+   to `reitit.ring.middleware.multipart`). We split it into two separate
+   middlewares — `multipart-parsing-middleware` does parsing via Ring and
+   `multipart-coercion-middleware` coerces the same way Reitit does it."
   (conj
-   ;; All of `ring-defaults-middleware`, except multipart, which must come
-   ;; after request coercion (see docstring).
-   (into [] (remove #{multipart-middleware}) ring-defaults-middleware)
+   ring-defaults-middleware
 
    format/format-negotiate-middleware
    format/format-response-middleware
@@ -185,4 +239,4 @@
    coercion/coerce-request-middleware
    coercion/coerce-response-middleware
 
-   multipart-middleware))
+   multipart-coercion-middleware))

--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -1,8 +1,9 @@
 (ns reitit.ring.middleware.defaults
   (:refer-clojure :exclude [compile])
-  (:require [reitit.coercion :as rc]
-            [reitit.ring.coercion :as coercion]
+  (:require [reitit.ring.coercion :as coercion]
             [reitit.ring.middleware.exception :as exception]
+            [reitit.ring.middleware.defaults.multipart
+             :refer [multipart-params-middleware multipart-coercion-middleware]]
             [reitit.ring.middleware.muuntaja :as format]
             [reitit.ring.middleware.parameters :as parameters]
             [ring.middleware.absolute-redirects :refer [wrap-absolute-redirects]]
@@ -12,7 +13,6 @@
             [ring.middleware.default-charset :refer [wrap-default-charset]]
             [ring.middleware.flash :refer [wrap-flash]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-            [ring.middleware.multipart-params :refer [wrap-multipart-params]]
             [ring.middleware.nested-params :refer [wrap-nested-params]]
             [ring.middleware.not-modified :refer [wrap-not-modified]]
             [ring.middleware.proxy-headers :refer [wrap-forwarded-remote-addr]]
@@ -95,23 +95,6 @@
               (when (get-in data [:defaults :params :urlencoded])
                 parameters/parameters-middleware))})
 
-(def multipart-parsing-middleware
-  "Parses multipart params into `:multipart-params` and `:params`, like
-   the stock `ring.middleware.multipart-params/wrap-multipart-params`.
-
-   Parsing only: coercion into `[:parameters :multipart]` is done by the
-   `multipart-coercion-middleware`, mounted after request coercion.
-
-   Splitting into separate parsing and coercion steps also lets coercion
-   errors surface inside `coercion/coerce-exceptions-middleware` as 400s
-   instead of escaping the chain as 500s."
-  {:name ::multipart-parsing
-   :compile (fn [data _]
-              (when-let [opts (get-in data [:defaults :params :multipart])]
-                (if (true? opts)
-                  wrap-multipart-params
-                  #(wrap-multipart-params % opts))))})
-
 (def nested-params-middleware
   {:name ::nested-params
    :compile (compile wrap-nested-params #(get-in % [:params :nested] false))})
@@ -140,41 +123,6 @@
                   (exception/create-exception-middleware handlers)
                   exception/exception-middleware)))})
 
-(defn- coerced-request [request coercers]
-  (if-let [coerced (if coercers (rc/coerce-request coercers request))]
-    (update request :parameters merge coerced)
-    request))
-
-(def multipart-coercion-middleware
-  "Coerces the multipart params pre-parsed by `multipart-parsing-middleware`
-   into `[:parameters :multipart]`.
-
-   Coercion only: the request body is not touched. Must be mounted after the
-   `coercion/coerce-request-middleware`, which overwrites `:parameters` and
-   would discard anything merged into it earlier.
-
-   It mounts only when multipart params are enabled in the `:defaults` route
-   data and the route has a `:multipart` params schema."
-  {:name ::multipart-coercion
-   :compile (fn [{:keys [parameters coercion] :as data} route-opts]
-              (when (and (get-in data [:defaults :params :multipart])
-                         (:multipart parameters))
-                (let [parameter-coercion {:multipart (rc/->ParameterCoercion
-                                                      :multipart-params :string true true)}
-                      opts (assoc route-opts ::rc/parameter-coercion parameter-coercion)
-                      coercers (rc/request-coercers coercion parameters opts)]
-                  {:data {:swagger {:consumes ^:replace #{"multipart/form-data"}}}
-                   :wrap (fn [handler]
-                           (fn
-                             ([request]
-                              (-> request
-                                  (coerced-request coercers)
-                                  (handler)))
-                             ([request respond raise]
-                              (-> request
-                                  (coerced-request coercers)
-                                  (handler respond raise)))))})))})
-
 (def ring-defaults-middleware
   "Applies the same middleware as `ring.middleware.defaults/wrap-defaults`,
    but as Reitit data-driven middleware with per-route compilation.
@@ -202,7 +150,7 @@
    cookies-middleware
 
    params-middleware
-   multipart-parsing-middleware
+   multipart-params-middleware
    nested-params-middleware
    keyword-params-middleware
 
@@ -213,18 +161,7 @@
 
 (def defaults-middleware
   "All of `ring-defaults-middleware`, plus Reitit's content negotiation
-   (using Muuntaja), exception and coercion middleware.
-
-   IMPLEMENTATION NOTE:
-   Reitit's multipart middleware parses and coerces in a single wrap, but
-   the two halves have contradictory placement requirements: parsing must
-   happen before the `nested-params`, `keyword-params` and `anti-forgery`
-   middleware, which expect multipart params merged into `:params`, while
-   the coercion result only survives after `coerce-request-middleware`,
-   which overwrites `:parameters` wholesale (see the note added in 0.10.0
-   to `reitit.ring.middleware.multipart`). We split it into two separate
-   middlewares — `multipart-parsing-middleware` does parsing via Ring and
-   `multipart-coercion-middleware` coerces the same way Reitit does it."
+   (using Muuntaja), exception and coercion middleware."
   (conj
    ring-defaults-middleware
 

--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -170,7 +170,9 @@
   "All of `ring-defaults-middleware`, plus Reitit's content negotiation
    (using Muuntaja), exception and coercion middleware."
   (conj
-   ring-defaults-middleware
+   ;; All of `ring-defaults-middleware`, except multipart, which must come
+   ;; after request coercion (see docstring).
+   (into [] (remove #{multipart-middleware}) ring-defaults-middleware)
 
    format/format-negotiate-middleware
    format/format-response-middleware
@@ -181,4 +183,6 @@
 
    coercion/coerce-exceptions-middleware
    coercion/coerce-request-middleware
-   coercion/coerce-response-middleware))
+   coercion/coerce-response-middleware
+
+   multipart-middleware))

--- a/src/reitit/ring/middleware/defaults/multipart.clj
+++ b/src/reitit/ring/middleware/defaults/multipart.clj
@@ -1,0 +1,66 @@
+(ns reitit.ring.middleware.defaults.multipart
+  "IMPLEMENTATION NOTE:
+   Reitit's multipart middleware parses and coerces in a single wrap, but
+   the two halves have contradictory placement requirements: parsing must
+   happen before the `nested-params`, `keyword-params` and `anti-forgery`
+   middleware, which expect multipart params merged into `:params`, while
+   the coercion result only survives after `coerce-request-middleware`,
+   which overwrites `:parameters` wholesale (see the note added in 0.10.0
+   to `reitit.ring.middleware.multipart`). We split it into two separate
+   middlewares — `multipart-params-middleware` does parsing via Ring and
+   `multipart-coercion-middleware` coerces the same way Reitit does it."
+  (:require [reitit.coercion :as rc]
+            [ring.middleware.multipart-params :refer [wrap-multipart-params]]))
+
+(def multipart-params-middleware
+  "Parses multipart params into `:multipart-params` and `:params`, like
+   the stock `ring.middleware.multipart-params/wrap-multipart-params`.
+
+   Parsing only: coercion into `[:parameters :multipart]` is done by the
+   `multipart-coercion-middleware`, mounted after request coercion.
+
+   Splitting into separate parsing and coercion steps also lets coercion
+   errors surface inside `coercion/coerce-exceptions-middleware` as 400s
+   instead of escaping the chain as 500s."
+  {:name ::multipart-params
+   :compile (fn [data _]
+              (when-let [opts (get-in data [:defaults :params :multipart])]
+                (if (true? opts)
+                  wrap-multipart-params
+                  #(wrap-multipart-params % opts))))})
+
+(defn- coerced-request [request coercers]
+  (if-let [coerced (if coercers (rc/coerce-request coercers request))]
+    (update request :parameters merge coerced)
+    request))
+
+;; The impl is taken from `reitit.ring.middleware.multipart` mostly verbatim
+(def multipart-coercion-middleware
+  "Coerces the multipart params pre-parsed by `multipart-params-middleware`
+   into `[:parameters :multipart]`.
+
+   Coercion only: the request body is not touched. Must be mounted after the
+   `coercion/coerce-request-middleware`, which overwrites `:parameters` and
+   would discard anything merged into it earlier.
+
+   It mounts only when multipart params are enabled in the `:defaults` route
+   data and the route has a `:multipart` params schema."
+  {:name ::multipart-coercion
+   :compile (fn [{:keys [parameters coercion] :as data} route-opts]
+              (when (and (get-in data [:defaults :params :multipart])
+                         (:multipart parameters))
+                (let [parameter-coercion {:multipart (rc/->ParameterCoercion
+                                                      :multipart-params :string true true)}
+                      opts (assoc route-opts ::rc/parameter-coercion parameter-coercion)
+                      coercers (rc/request-coercers coercion parameters opts)]
+                  {:data {:swagger {:consumes ^:replace #{"multipart/form-data"}}}
+                   :wrap (fn [handler]
+                           (fn
+                             ([request]
+                              (-> request
+                                  (coerced-request coercers)
+                                  (handler)))
+                             ([request respond raise]
+                              (-> request
+                                  (coerced-request coercers)
+                                  (handler respond raise)))))})))})


### PR DESCRIPTION
Hello Ferdinand!

After using your handy lib for quite some time now — kudos for putting it together, btw! — I stumbled upon an issue with multipart request params handling.

The thing is, `defaults-middleware` mounts the multipart middleware _before_ `coerce-request-middleware`, which then overwrites `:parameters` wholesale, so `[:parameters :multipart]` is always lost. `reitit`'s multipart middleware [docstring explicitly requires the opposite order](https://github.com/metosin/reitit/blob/0.10.1/modules/reitit-middleware/src/reitit/ring/middleware/multipart.clj#L63-L64).

The note was added recently, in `0.10.0` (in [`3e0f1d3`](https://github.com/metosin/reitit/commit/3e0f1d3188)) — it simply wasn't there when you composed `defaults-middleware`, — but the behavior itself (`coerce-request` replacing `:parameters` wholesale via `fast-assoc`) has been there all along.

Here's how I approached this issue.

**Why not just reorder:** there's no single slot that works for reitit's multipart middleware, because it parses *and* coerces in one wrap, and the two halves have contradictory placement requirements. Parsing must stay early — before `nested-params`/`keyword-params` (multipart fields merged into `:params` get keywordized/nested there) and before `anti-forgery` (a CSRF token posted as a hidden field in a multipart form lives in the parsed body) — while the coercion result only survives after `coerce-request-middleware`. Moving the middleware to the end would have silently broken both of those for existing users.

The fix splits the two halves:

- `multipart-params-middleware` — parse-only (Ring's stock `wrap-multipart-params`), mounted in the same position as before, so `:params`, nested/keyword-params and anti-forgery behavior are unchanged;
- `multipart-coercion-middleware` — coercion-only, mounted at the end of `defaults-middleware` (mirroring where reitit's own documented chain puts its multipart middleware); it coerces the already-parsed `:multipart-params` into `[:parameters :multipart]` exactly the way reitit does, without touching the request body. The swagger `:consumes` route data reitit's middleware used to contribute moved here, gated on the route having a `:multipart` schema.

**Side effects of the split** (all arguably fixes, but flagging for your sign-off):

- Invalid multipart params now surface as a proper **400**: coercion runs inside `coerce-exceptions-middleware`, whereas previously the coercion error was thrown in the outer ring-defaults region and escaped the chain as a 500.
- Multipart bodies are now parsed whenever `:defaults {:params {:multipart ...}}` is set, even without a `:parameters {:multipart ...}` schema — matching the `ring-defaults` contract. Previously parsing was silently skipped without a schema, which notably meant plain `ring-defaults-middleware` users (no coercion, hence no schema) got no multipart parsing at all.
- No more double coercion work (the old early coercion result was computed and then discarded).

**One breaking change to be aware of:** the public var `multipart-middleware` is renamed to `multipart-params-middleware` (and its `:name` from `::multipart` to `::multipart-parsing`), which affects anyone composing a custom stack from the individual vars. I'm personally in favor of keeping this small intentional break — "power users", if any, will get a loud missing-var error on upgrade and notice the changed multipart behavior, rather than inheriting it silently — but happy to go another way if you prefer.

**Verification:** exercised end-to-end on a closed-source project against reitit `0.10.1` with malli coercion — a real multipart request through the assembled `defaults-middleware`: valid upload populates `[:parameters :multipart]` (previously always `nil`), invalid part returns 400 (previously an escaped exception), and keywordized `:params`, raw `:multipart-params` and `:path` coercion all intact.

Hope that helps to make the library even better!

Cheers,
Mark

P.S. It might also be worth updating outdated dependencies. I didn't do this in scope of the fix, leaving it up to you.