### PR TITLE
Fix custom `:exception` handlers being shadowed for coercion errors

### DIFF
--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -168,11 +168,11 @@
    format/format-negotiate-middleware
    format/format-response-middleware
 
+   coercion/coerce-exceptions-middleware
    exception-middleware
 
    format/format-request-middleware
 
-   coercion/coerce-exceptions-middleware
    coercion/coerce-request-middleware
    coercion/coerce-response-middleware
 

--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -174,6 +174,8 @@
    format/format-negotiate-middleware
    format/format-response-middleware
 
+   ;; The order is important: `coerce-exceptions-middleware` must stay outside
+   ;; `exception-middleware`, which usually answers coercion errors too.
    coerce-exceptions-middleware
    exception-middleware
 

--- a/src/reitit/ring/middleware/defaults.clj
+++ b/src/reitit/ring/middleware/defaults.clj
@@ -123,6 +123,12 @@
                   (exception/create-exception-middleware handlers)
                   exception/exception-middleware)))})
 
+(def coerce-exceptions-middleware
+  {:name ::coerce-exceptions
+   :compile (fn [data route-opts]
+              (when-not (get-in data [:defaults :exception])
+                ((:compile coercion/coerce-exceptions-middleware) data route-opts)))})
+
 (def ring-defaults-middleware
   "Applies the same middleware as `ring.middleware.defaults/wrap-defaults`,
    but as Reitit data-driven middleware with per-route compilation.
@@ -168,7 +174,7 @@
    format/format-negotiate-middleware
    format/format-response-middleware
 
-   coercion/coerce-exceptions-middleware
+   coerce-exceptions-middleware
    exception-middleware
 
    format/format-request-middleware


### PR DESCRIPTION
Hello again Ferdinand!

Here's another fix — to an issue I've been using a workaround for for quite some time now.

The `defaults-middleware` mounted `reitit.ring.coercion/coerce-exceptions-middleware` *inside* `exception-middleware`. Coercion exceptions are thrown deeper still, so the inner middleware always caught them first and answered with a raw `coercion/encode-error` body. Any `::coercion/request-coercion` / `::coercion/response-coercion` entry in `:defaults {:exception {:handlers ...}}` was dead code, and `::exception/wrap` never fired for those failures either — so they also bypassed user logging.

Two parts of the proposed fix:

1. **Reorder** — `coerce-exceptions-middleware` moves outside `exception-middleware`, which now gets first refusal on coercion exceptions. `exception-middleware` stays outside `format-request-middleware` (so `:muuntaja/decode` is still handled) and inside `format-response-middleware` (so error bodies are still encoded).
2. **Don't mount `coerce-exceptions-middleware` when it cannot fire** — after the reorder, `exception-middleware` catches `Throwable` and either answers or fails with an exception of its own, whose `:type` is never a coercion type. So whenever it is mounted the outer wrapper is unreachable; it is now only mounted as the standalone fallback, when `:defaults` has no `:exception`.

Behaviour changes when `:defaults {:exception ...}` is set:

- Coercion errors reach your handlers, including `::exception/wrap`, and fall through to `::exception/default` when unmapped (previously they were the one exception type that bypassed it).
- An exception handler that re-throws for the original coercion exception no longer falls back to reitit's raw response — it propagates.

OOS: handler maps with no matching entry and no `::exception/default` still NPE inside reitit's handler lookup. That predates this change and is not specific to coercion.

Hope that helps!

Cheers,
Mark

P.S. It might also be worth updating outdated dependencies. I didn't do this in scope of the fix, leaving it up to you.